### PR TITLE
Commit - Changes to Region, BlockListenerEvent

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
+++ b/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
@@ -15,7 +15,6 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.Server;
 import org.bukkit.World;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.plugin.Plugin;

--- a/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
+++ b/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
@@ -504,6 +504,7 @@ public class BlockEventListener implements Listener
     {
     final Location eventLoc = event.getLocation();
     final List<Region> regions = this.regionModule.getRegionManager().getRegionsAtLoc(eventLoc);
+    
     if (regions.isEmpty())
     Player p = event.getPlayer();
     }

--- a/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
+++ b/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
@@ -394,8 +394,6 @@ public class BlockEventListener implements Listener
             return;
         case LEVER:
             return;
-        case PAINTING:
-            return;
         case STONE_BUTTON:
             return;
         case WATER:
@@ -510,11 +508,10 @@ public class BlockEventListener implements Listener
     if ((event.getAction() == Action.RIGHT_CLICK_BLOCK) || (event.getAction() == Action.LEFT_CLICK_BLOCK))
     {
       if ((event.getClickedBlock().getType() != null) && (event.getClickedBlock().getType() == Material.DRAGON_EGG))
-      {
-        if (!p.hasPermission("VoxelGuest.Regions.Eggport"))
-      }
+        {
         event.setCancelled(true);
         return;
+        }
     }
 
     @EventHandler

--- a/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
+++ b/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
@@ -1,7 +1,6 @@
 package com.thevoxelbox.voxelguest.modules.regions.listener;
 
 import java.util.List;
-import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 
 import com.google.common.base.Preconditions;
 import com.thevoxelbox.voxelguest.modules.regions.Region;

--- a/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
+++ b/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
@@ -335,6 +335,8 @@ public class BlockEventListener implements Listener
             return;
         case DISPENSER:
             return;
+        case DRAGON_EGG:
+            return;
         case GLOWING_REDSTONE_ORE:
             return;
         case IRON_DOOR:

--- a/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
+++ b/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
@@ -509,6 +509,27 @@ public class BlockEventListener implements Listener
             }
             return;
         }
+        
+    @EventHandler
+    public final void onPaintingBreak(final HangingBreakEvent event)
+    {
+        final Location eventLoc = event.getEntity().getLocation();
+        final Region region = this.regionModule.getRegionManager().getRegionAtLoc(eventLoc);
+
+        if (region != null)
+        {
+            if (!region.isBuildingRestricted())
+            {
+                if (event.getRemover() instanceof Player)
+                {
+                    if (!this.regionModule.getRegionManager().canPlayerModify((Player) event.getRemover(), event.getEntity().getLocation()))
+                    {
+                        event.setCancelled(true);
+                    }
+                }
+            }
+            return;
+        }
         event.setCancelled(true);
         return;
     }

--- a/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
+++ b/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
@@ -498,14 +498,15 @@ public class BlockEventListener implements Listener
         }
         return;
     }
+    
     @EventHandler
-    public void onPlayerInteractEvent(PlayerInteractEvent event)
+    public final void onPlayerInteractEvent(PlayerInteractEvent event)
     {
     final Location eventLoc = event.getLocation();
     final List<Region> regions = this.regionModule.getRegionManager().getRegionsAtLoc(eventLoc);
     if (regions.isEmpty())
     Player p = event.getPlayer();
-    
+    }
     if ((event.getAction() == Action.RIGHT_CLICK_BLOCK) || (event.getAction() == Action.LEFT_CLICK_BLOCK))
     {
       if ((event.getClickedBlock().getType() != null) && (event.getClickedBlock().getType() == Material.DRAGON_EGG))
@@ -515,7 +516,6 @@ public class BlockEventListener implements Listener
         event.setCancelled(true);
         return;
     }
-  }
 
     @EventHandler
     public final void onPaintingBreak(final HangingBreakByEntityEvent event)
@@ -537,6 +537,7 @@ public class BlockEventListener implements Listener
             }
         return;
         }
+    }    
         
     @EventHandler
     public final void onPaintingBreak(final HangingBreakEvent event)

--- a/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
+++ b/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
@@ -1,6 +1,7 @@
 package com.thevoxelbox.voxelguest.modules.regions.listener;
 
 import java.util.List;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 
 import com.google.common.base.Preconditions;
 import com.thevoxelbox.voxelguest.modules.regions.Region;
@@ -13,6 +14,13 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.Server;
+import org.bukkit.World;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockFadeEvent;
 import org.bukkit.event.block.BlockFormEvent;
@@ -488,6 +496,24 @@ public class BlockEventListener implements Listener
         }
         return;
     }
+    @EventHandler
+    public void onPlayerInteractEvent(PlayerInteractEvent event)
+    {
+    final Location eventLoc = event.getLocation();
+    final List<Region> regions = this.regionModule.getRegionManager().getRegionsAtLoc(eventLoc);
+    if (regions.isEmpty())
+    Player p = event.getPlayer();
+    
+    if ((event.getAction() == Action.RIGHT_CLICK_BLOCK) || (event.getAction() == Action.LEFT_CLICK_BLOCK))
+    {
+      if ((event.getClickedBlock().getType() != null) && (event.getClickedBlock().getType() == Material.DRAGON_EGG))
+      {
+        if (!p.hasPermission("VoxelGuest.Regions.Eggport"))
+      }
+        event.setCancelled(true);
+        return;
+    }
+  }
 
     @EventHandler
     public final void onPaintingBreak(final HangingBreakByEntityEvent event)

--- a/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
+++ b/src/main/java/com/thevoxelbox/voxelguest/modules/regions/listener/BlockEventListener.java
@@ -387,6 +387,8 @@ public class BlockEventListener implements Listener
             return;
         case LEVER:
             return;
+        case PAINTING:
+            return;
         case STONE_BUTTON:
             return;
         case WATER:
@@ -507,7 +509,7 @@ public class BlockEventListener implements Listener
                     }
                 }
             }
-            return;
+        return;
         }
         
     @EventHandler
@@ -528,7 +530,7 @@ public class BlockEventListener implements Listener
                     }
                 }
             }
-            return;
+        return;
         }
         event.setCancelled(true);
         return;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -22,7 +22,7 @@ commands:
     aliases: [vgregion, vregion]
     permission: voxelguest.regions.modifyregion
   ban:
-    aliases: [vban]
+    aliases: [vban, ban]
     permission: voxelguest.asshat.ban
     description: Bans a player from logging on to the server
   banreason:
@@ -34,7 +34,7 @@ commands:
     permission: voxelguest.asshat.freeze
     description: Prevents everyone on the server from moving unless they have the exclusion permishion.
   kick:
-    aliases: [vkick]
+    aliases: [vkick, kick]
     permission: voxelguest.asshat.kick
     description: Forces a player to disconnect from the server
   mute:
@@ -46,7 +46,7 @@ commands:
     permission: voxelguest.asshat.soapbox
     description: Perevents everyone that dose not have the exclusion permishion from chatting
   unban:
-    aliases: [vunban]
+    aliases: [vunban, unban]
     permission: voxelguest.asshat.unban
     description: Unbans a player
   unmute:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -32,7 +32,7 @@ commands:
   freeze:
     aliases: [vfreeze]
     permission: voxelguest.asshat.freeze
-    description: Prevents everyone on the server from moving unless they have the exclusion permishion.
+    description: Prevents everyone on the server from moving unless they have the exclusion permission
   kick:
     aliases: [vkick, kick]
     permission: voxelguest.asshat.kick
@@ -44,7 +44,7 @@ commands:
   soapbox:
     aliases: [vsoapbox]
     permission: voxelguest.asshat.soapbox
-    description: Perevents everyone that dose not have the exclusion permishion from chatting
+    description: Prevents everyone that does not have the exclusion permission from chatting
   unban:
     aliases: [vunban, unban]
     permission: voxelguest.asshat.unban
@@ -84,7 +84,7 @@ commands:
   afk:
     aliases: [afk, vafk]
     permission: voxelguest.general.afk
-    description: Tells the server the the player is away from their keyboard.
+    description: Tells the server that the player is away from their keyboard.
   addafkmessage:
     aliases: [addafkmessage, addafkmsg, vaddafkmsg]
     permission: voxelguest.general.createafkmsg
@@ -95,12 +95,12 @@ commands:
     description: Makes the exp bar a lag meter
   wlreview:
     aliases: [wlreview, vwlreview]
-    description: Submits a Whitelist review ticket
+    description: Submits a whitelist review ticket
   helper:
     aliases: [helper, vhelper]
     permission: voxelguest.helper.control
-    description: Helps mannage helpers
+    description: Helps manage helpers
   helperreview:
     aliases: [helperreview, hreview]
     permission: voxelguest.helper.review
-    description: Reviews a Whitelist review ticket    
+    description: Reviews a whitelist review ticket    


### PR DESCRIPTION
This commit includes...
- Block Listener Changes
  ~ Ender_Egg Porting disabled (To avoid unintentional griefing)
  ~ Updated HangingBreakEvent added other event to listener
- Plugin.yml
  ~ Various Spelling fixes
  ~ Added other regular aliases

Showed this to ayyy today said it looked good to what he could see, he told me to ask Mike or Mono about this, wanted to see if this kind of protection should/can be implemented. Found the Porting issue to be a problem somewhat on the server.

p.s Sorry for the large amount of commits, apparently github stacks commits based on branch changes even in my personal repository version.

Related change regarding https://github.com/TVPT/VoxelGuest/issues/66
